### PR TITLE
Fix validation order

### DIFF
--- a/addon.config.json
+++ b/addon.config.json
@@ -1,6 +1,6 @@
 {
   "AddonUUID": "00000000-0000-0000-0000-0000000f11e5",
-  "AddonVersion": "0.5.10",
+  "AddonVersion": "0.5.11",
   "DebugPort": 4500,
   "WebappBaseUrl": "https://app.sandbox.pepperi.com",
   "DefaultEditor": "main",

--- a/server-side/pfs.service.ts
+++ b/server-side/pfs.service.ts
@@ -132,15 +132,16 @@ export class PfsService
 
 	private async validateUploadRequest() 
 	{
-		if(this.getPathDepth() > MAXIMAL_TREE_DEPTH)
-		{
-			throw new Error(`Requested path is deeper than the maximum allowed depth of ${MAXIMAL_TREE_DEPTH}.`);
-		}
 		await this.validateAddonSecretKey();
 
 		if (!this.request.body.Key) 
 		{
 			throw new Error("Missing mandatory field 'Key'");
+		}
+
+		if(this.getPathDepth() > MAXIMAL_TREE_DEPTH)
+		{
+			throw new Error(`Requested path is deeper than the maximum allowed depth of ${MAXIMAL_TREE_DEPTH}.`);
 		}
 		
 		if (this.request.body.Thumbnails) 


### PR DESCRIPTION
Previous validation order failed when receiving a POST body that doesn't have a Key property.